### PR TITLE
Make it possible to set another title for the newest job on the main page

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,6 +13,9 @@ pygmentsCodeFences=true
   main = "Hi, I'm Edna :wave:"
   sub = "I'm a Web Developer and Entrepreneur"
 
+[params.main]
+  latestPublishHeader = "My Latest Project"
+
 [taxonomies]
   design = "designs"
   tech = "techs"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <h1>{{ .Title | markdownify }}</h1>
 {{ .Content }}
 
-<h2>My Latest Job</h2>
+<h2>{{ .Site.Params.latestPublishHeader | default "My Latest Job" }}</h2>
   {{ $pages := where site.RegularPages "Type" "in" .Site.Params.mainSections }}
   {{ range first 1 $pages }}
     {{ if in .Site.Params.mainSections "portfolio" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <h1>{{ .Title | markdownify }}</h1>
 {{ .Content }}
 
-<h2>{{ .Site.Params.latestPublishHeader | default "My Latest Job" }}</h2>
+<h2>{{ .Site.Params.main.latestPublishHeader | default "My Latest Job" }}</h2>
   {{ $pages := where site.RegularPages "Type" "in" .Site.Params.mainSections }}
   {{ range first 1 $pages }}
     {{ if in .Site.Params.mainSections "portfolio" }}


### PR DESCRIPTION
When using your hugo theme for my website, I wanted to change the title for the newest job. With this change, it is possible :slightly_smiling_face: 

I tried to find a better name for `latestPublishHeader`, but the best I could think of was `latestJobTitle`, and I don't know if that is any better. Additionally, I created a new subcategory `main` for this, because I didn't want to put it directly inside of `params`