### PR TITLE
add option for safe rendering

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,7 @@ pygmentsCodeFences=true
   breadcrumb = true
   accentColor = "#FD3519"
   mainSections = ['portfolio'] # values: ['post', 'portfolio'] only accept one section, to be displayed bellow 404
+  rendererSafe = false # set to true if wish to remove the unsafe renderer setting below (recommended). Titles will not be run through markdownify
 
 [params.notFound]
   gopher = "/images/gopher.png" # checkout https://gopherize.me/

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,12 @@
 {{ partial "header" .}}
 
-<h1>{{ .Title | markdownify }}</h1>
-{{ .Content | markdownify }}
+<h1>{{ .Title }}</h1>
+{{ if .Site.Params.rendererSafe }}
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+{{ else }}
+  <h1>{{ .Title | markdownify }}</h1>
+  {{ .Content | markdownify }}
+{{ end}}
 
 {{ partial "footer" .}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,11 @@
 {{ partial "header" .}}
 
-<h1>{{ .Title | markdownify }}</h1>
+{{ if .Site.Params.rendererSafe }}
+  <h1>{{ .Title }}</h1>
+{{ else }}
+  <h1>{{ .Title | markdownify }}</h1>
+{{ end}}
+
 {{ .Content }}
 
 <h2>{{ .Site.Params.main.latestPublishHeader | default "My Latest Job" }}</h2>


### PR DESCRIPTION
Added `rendererSafe` option to `config.toml`.  If this is set to true, then the theme will work without the renderer being set to unsafe and the `[markup]` section at the bottom of `config.toml` can be removed.

If  `rendererSafe` is set to true, then titles can no longer contain markdown.

For backwards compatibility, if `rendererSafe` is missing, then it defaults to false.