### PR TITLE
Suppress listing of child pages

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,7 @@ pygmentsCodeFences=true
   breadcrumb = true
   accentColor = "#FD3519"
   mainSections = ['portfolio'] # values: ['post', 'portfolio'] only accept one section, to be displayed bellow 404
+  rendererSafe = false # set to true if wish to remove the unsafe renderer setting below (recommended). Titles will not be run through markdownify
 
 [params.notFound]
   gopher = "/images/gopher.png" # checkout https://gopherize.me/

--- a/exampleSite/content/post/config-file.md
+++ b/exampleSite/content/post/config-file.md
@@ -41,6 +41,7 @@ pygmentsCodeFences=true
   breadcrumb = true
   accentColor = "#FD3519"
   mainSections = ['portfolio']
+  rendererSafe = true # set to true if the renderer is not marked unsafe
 
 [params.notFound]
   gopher = "/images/gopher.png"

--- a/exampleSite/content/post/pages.md
+++ b/exampleSite/content/post/pages.md
@@ -1,0 +1,16 @@
+---
+title: "Pages"
+description: Information on setting up pages
+date: 2019-04-20T16:18:12+01:00
+publishDate: 2019-04-20T19:12:12+01:00
+---
+
+Variables you can use in pages
+
+<!--more-->
+
+The following page variables can be used in default list pages:
+
+* **pagesListSuppressed**
+    * false (or missing) - child pages are listed
+    * true - child pages are not listed

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,10 +2,12 @@
 
   <h1 id="title"> {{ .Title }}</h1>
   <p>{{ .Content }}</p>
-  <ul id="list">
-    {{ range .Pages }}
-      {{ .Render "li" }}
-    {{ end }}
-  </ul>
+  {{ if not $.Params.pagesListSuppressed }}
+    <ul id="list">
+      {{ range .Pages }}
+        {{ .Render "li" }}
+      {{ end }}
+    </ul>
+  {{ end }}
 
 {{ partial "footer" .}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,12 @@
 {{ partial "header" .}}
 
-<h1>{{ .Title | markdownify }}</h1>
-{{ .Content | markdownify }}
+<h1>{{ .Title }}</h1>
+{{ if .Site.Params.rendererSafe }}
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+{{ else }}
+  <h1>{{ .Title | markdownify }}</h1>
+  {{ .Content | markdownify }}
+{{ end}}
 
 {{ partial "footer" .}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,5 @@
 {{ partial "header" .}}
 
-<h1>{{ .Title }}</h1>
 {{ if .Site.Params.rendererSafe }}
   <h1>{{ .Title }}</h1>
   {{ .Content }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,11 @@
 {{ partial "header" .}}
 
-<h1>{{ .Title | markdownify }}</h1>
+{{ if .Site.Params.rendererSafe }}
+  <h1>{{ .Title }}</h1>
+{{ else }}
+  <h1>{{ .Title | markdownify }}</h1>
+{{ end}}
+
 {{ .Content }}
 
 <h2>{{ .Site.Params.main.latestPublishHeader | default "My Latest Job" }}</h2>


### PR DESCRIPTION
Allows a (default) list page to contain content but not list child pages. Child pages can be suppressed by including the following parameter in the pages front matter:

`pagesListSuppressed = true`