### PR TITLE
jatkinson1000/add copy code button option

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -28,6 +28,7 @@ pygmentsCodeFences=true
   accentColor = "#FD3519"
   mainSections = ['portfolio'] # values: ['post', 'portfolio'] only accept one section, to be displayed bellow 404
   rendererSafe = false # set to true if wish to remove the unsafe renderer setting below (recommended). Titles will not be run through markdownify
+  copyCodeButtonEnabled = false # set to true if copy button should be placed on top of code blocks
 
 [params.notFound]
   gopher = "/images/gopher.png" # checkout https://gopherize.me/

--- a/exampleSite/content/post/config-file.md
+++ b/exampleSite/content/post/config-file.md
@@ -42,6 +42,8 @@ pygmentsCodeFences=true
   accentColor = "#FD3519"
   mainSections = ['portfolio']
   rendererSafe = true # set to true if the renderer is not marked unsafe
+  copyCodeButtonEnabled = false # set to true if copy button should be placed on top of code blocks
+
 
 [params.notFound]
   gopher = "/images/gopher.png"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -25,5 +25,10 @@
       }
     });
   </script>
+  {{ if $.Site.Params.copyCodeButtonEnabled }}
+    {{ if (findRE "<pre" .Content 1) }}
+      <script src="/js/copy-code-button.js"></script>
+    {{ end }}
+  {{ end }}
 </body>
 </html>

--- a/static/js/copy-code-button.js
+++ b/static/js/copy-code-button.js
@@ -33,14 +33,4 @@ function addCopyButtons(clipboard) {
 
 if (navigator && navigator.clipboard) {
     addCopyButtons(navigator.clipboard);
-} else {
-    // var script = document.createElement('script');
-    // script.src = 'https://cdnjs.cloudflare.com/ajax/libs/clipboard-polyfill/2.7.0/clipboard-polyfill.promise.js';
-    // script.integrity = 'sha256-waClS2re9NUbXRsryKoof+F9qc1gjjIhc2eT7ZbIv94=';
-    // script.crossOrigin = 'anonymous';
-    // script.onload = function() {
-    //     addCopyButtons(clipboard);
-    // };
-
-    // document.body.appendChild(script);
 }

--- a/static/js/copy-code-button.js
+++ b/static/js/copy-code-button.js
@@ -1,0 +1,46 @@
+function addCopyButtons(clipboard) {
+    document.querySelectorAll('pre > code').forEach(function (codeBlock) {
+        var button = document.createElement('button');
+        button.className = 'copy-code-button';
+        button.type = 'button';
+        button.innerText = 'Copy';
+
+        button.addEventListener('click', function () {
+            clipboard.writeText(codeBlock.innerText).then(function () {
+                /* Chrome doesn't seem to blur automatically,
+                   leaving the button in a focused state. */
+                button.blur();
+
+                button.innerText = 'Copied!';
+
+                setTimeout(function () {
+                    button.innerText = 'Copy';
+                }, 2000);
+            }, function (error) {
+                button.innerText = 'Error';
+            });
+        });
+
+        var pre = codeBlock.parentNode;
+        if (pre.parentNode.classList.contains('highlight')) {
+            var highlight = pre.parentNode;
+            highlight.parentNode.insertBefore(button, highlight);
+        } else {
+            pre.parentNode.insertBefore(button, pre);
+        }
+    });
+}
+
+if (navigator && navigator.clipboard) {
+    addCopyButtons(navigator.clipboard);
+} else {
+    // var script = document.createElement('script');
+    // script.src = 'https://cdnjs.cloudflare.com/ajax/libs/clipboard-polyfill/2.7.0/clipboard-polyfill.promise.js';
+    // script.integrity = 'sha256-waClS2re9NUbXRsryKoof+F9qc1gjjIhc2eT7ZbIv94=';
+    // script.crossOrigin = 'anonymous';
+    // script.onload = function() {
+    //     addCopyButtons(clipboard);
+    // };
+
+    // document.body.appendChild(script);
+}


### PR DESCRIPTION
This builds on the seemingly stagnated PR #27 of @pbklink to remove the redundant else clause and comments as requested.

To quote @pbklink:
> Includes a feature where a copy button can be added to all code blocks in a website.
> This feature can be enabled by setting the following parameter in `config.toml`
> `copyCodeButtonEnabled = true`
> Note that this feature requires a JavaScript script. This script is included under the new `static/js` directory.
